### PR TITLE
Add Chief Privacy and Security Officer contact info

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
             <div class="col-md-4">
 
                 <p class="lead">info@winterlightlabs.com</p>
-                <p>
+                <p style="margin-bottom: 20px;">
                   WinterLight Labs Inc<br>
                   Attn: Liam Kaufman<br>
                   JLABS @ Toronto<br>
@@ -259,6 +259,10 @@
                   661 University Avenue<br>
                   Suite 1300<br>
                   Toronto, ON  M5G 0B7
+                </p>
+
+                <p class="small">
+                  To get in touch with our Chief Privacy and Security Officer, please send your correspondence to: info@winterlightlabs.com or via mail to our address listed above.
                 </p>
 
             </div>


### PR DESCRIPTION
This is required as part of our PIA: "Contact information for designated individual may be posted on the website or included in a poster or brochure."

I've added it to the index page under Contact info.